### PR TITLE
Update events and preferences API usage

### DIFF
--- a/lib/src/events/calendar_event.dart
+++ b/lib/src/events/calendar_event.dart
@@ -1,29 +1,45 @@
 class CalendarEvent {
   final String id;
   final String title;
-  final DateTime start;
-  final DateTime end;
+  final DateTime startTime;
+  final DateTime endTime;
+  final String description;
+  final String location;
+  final List<String> attendees;
+  final bool isAllDay;
 
   CalendarEvent({
     required this.id,
     required this.title,
-    required this.start,
-    required this.end,
+    required this.startTime,
+    required this.endTime,
+    this.description = '',
+    this.location = '',
+    this.attendees = const [],
+    this.isAllDay = false,
   });
 
   factory CalendarEvent.fromJson(Map<String, dynamic> json) {
     return CalendarEvent(
       id: json['id'] as String,
       title: json['title'] as String? ?? '',
-      start: DateTime.parse(json['start']),
-      end: DateTime.parse(json['end']),
+      startTime: DateTime.parse(json['start_time'] ?? json['start'] ?? ''),
+      endTime: DateTime.parse(json['end_time'] ?? json['end'] ?? ''),
+      description: json['description'] as String? ?? '',
+      location: json['location'] as String? ?? '',
+      attendees: (json['attendees'] as List<dynamic>?)?.cast<String>() ?? const [],
+      isAllDay: json['is_all_day'] as bool? ?? false,
     );
   }
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'title': title,
-        'start': start.toIso8601String(),
-        'end': end.toIso8601String(),
+        'start_time': startTime.toIso8601String(),
+        'end_time': endTime.toIso8601String(),
+        'description': description,
+        'location': location,
+        'attendees': attendees,
+        'is_all_day': isAllDay,
       };
 }

--- a/lib/src/events/event_list_screen.dart
+++ b/lib/src/events/event_list_screen.dart
@@ -39,8 +39,8 @@ class _EventListScreenState extends State<EventListScreen> {
           final CalendarEvent e = eventProvider.events[index];
           return ListTile(
             title: Text(e.title),
-            subtitle:
-                Text('${e.start} - ${e.end}'),
+            subtitle: Text(
+                '${e.startTime} - ${e.endTime}\n${e.location.isNotEmpty ? e.location : ''}'),
           );
         },
       );

--- a/lib/src/events/event_provider.dart
+++ b/lib/src/events/event_provider.dart
@@ -3,6 +3,7 @@ import '../services/calendar_service.dart';
 import '../services/cache_service.dart';
 import '../services/connectivity_service.dart';
 import 'calendar_event.dart';
+import 'events_response.dart';
 
 class EventProvider with ChangeNotifier {
   final CalendarService _calendarService;
@@ -31,7 +32,9 @@ class EventProvider with ChangeNotifier {
 
     if (_connectivityService.isOnline) {
       try {
-        _events = await _calendarService.fetchEvents();
+        final EventsResponse response =
+            await _calendarService.fetchUpcomingEvents();
+        _events = response.events;
         await _cacheService.saveList(
             'events', _events.map((e) => e.toJson()).toList());
         _error = null;

--- a/lib/src/events/events_response.dart
+++ b/lib/src/events/events_response.dart
@@ -1,0 +1,34 @@
+import 'calendar_event.dart';
+
+class EventsResponse {
+  final String userId;
+  final List<CalendarEvent> events;
+  final Map<String, DateTime> timeRange;
+  final int totalEvents;
+
+  EventsResponse({
+    required this.userId,
+    required this.events,
+    required this.timeRange,
+    required this.totalEvents,
+  });
+
+  factory EventsResponse.fromJson(Map<String, dynamic> json) {
+    final range = <String, DateTime>{};
+    if (json['time_range'] is Map<String, dynamic>) {
+      json['time_range'].forEach((key, value) {
+        if (value is String) {
+          range[key] = DateTime.parse(value);
+        }
+      });
+    }
+    return EventsResponse(
+      userId: json['user_id'] as String? ?? '',
+      events: (json['events'] as List<dynamic>? ?? [])
+          .map((e) => CalendarEvent.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      timeRange: range,
+      totalEvents: json['total_events'] as int? ?? 0,
+    );
+  }
+}

--- a/lib/src/preferences/preferences_screen.dart
+++ b/lib/src/preferences/preferences_screen.dart
@@ -24,7 +24,7 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
   Widget build(BuildContext context) {
     final prefsProvider = context.watch<PreferencesProvider>();
     final connectivity = context.watch<ConnectivityService>();
-    final prefs = prefsProvider.preferences ?? UserPreferences(darkMode: false);
+    final prefs = prefsProvider.preferences;
 
     return Scaffold(
       appBar: AppBar(title: const Text('Orion Preferences')),
@@ -42,9 +42,12 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
           if (prefsProvider.isLoading)
             const Expanded(
                 child: Center(child: CircularProgressIndicator()))
+          else if (prefs == null)
+            const Expanded(child: Center(child: Text('No preferences')))
           else
             Expanded(
               child: ListView(
+                padding: const EdgeInsets.all(8),
                 children: [
                   SwitchListTile(
                     title: const Text('Dark Mode'),
@@ -54,6 +57,21 @@ class _PreferencesScreenState extends State<PreferencesScreen> {
                       prefsProvider.updatePreferences(updated);
                     },
                   ),
+                  ListTile(
+                    title: const Text('Time Zone'),
+                    subtitle: Text(prefs.timeZone),
+                  ),
+                  ...prefs.workingHours.entries.map(
+                    (e) => ListTile(
+                      title: Text('Working Hours ${e.key}'),
+                      subtitle: Text('${e.value.start} - ${e.value.end}'),
+                    ),
+                  ),
+                  if (prefs.daysOff.isNotEmpty)
+                    ListTile(
+                      title: const Text('Days Off'),
+                      subtitle: Text(prefs.daysOff.join(', ')),
+                    ),
                 ],
               ),
             ),

--- a/lib/src/preferences/user_preferences.dart
+++ b/lib/src/preferences/user_preferences.dart
@@ -1,17 +1,106 @@
-class UserPreferences {
-  final bool darkMode;
+class TimeWindow {
+  final String start;
+  final String end;
 
-  UserPreferences({required this.darkMode});
+  TimeWindow({required this.start, required this.end});
 
-  factory UserPreferences.fromJson(Map<String, dynamic> json) {
-    return UserPreferences(darkMode: json['darkMode'] as bool? ?? false);
+  factory TimeWindow.fromJson(Map<String, dynamic> json) {
+    return TimeWindow(
+      start: json['start'] as String? ?? '',
+      end: json['end'] as String? ?? '',
+    );
   }
 
   Map<String, dynamic> toJson() => {
+        'start': start,
+        'end': end,
+      };
+}
+
+class UserPreferences {
+  final String userId;
+  final String timeZone;
+  final Map<String, TimeWindow> workingHours;
+  final List<TimeWindow> preferredMeetingTimes;
+  final List<String> daysOff;
+  final int preferredBreakDurationMinutes;
+  final int workBlockMaxDurationMinutes;
+  final int createdAt;
+  final int updatedAt;
+  final bool darkMode;
+
+  UserPreferences({
+    required this.userId,
+    required this.timeZone,
+    required this.workingHours,
+    required this.preferredMeetingTimes,
+    required this.daysOff,
+    required this.preferredBreakDurationMinutes,
+    required this.workBlockMaxDurationMinutes,
+    required this.createdAt,
+    required this.updatedAt,
+    this.darkMode = false,
+  });
+
+  factory UserPreferences.fromJson(Map<String, dynamic> json) {
+    final wh = <String, TimeWindow>{};
+    if (json['working_hours'] is Map<String, dynamic>) {
+      (json['working_hours'] as Map<String, dynamic>).forEach((k, v) {
+        if (v is Map<String, dynamic>) {
+          wh[k] = TimeWindow.fromJson(v);
+        }
+      });
+    }
+    return UserPreferences(
+      userId: json['user_id'] as String? ?? '',
+      timeZone: json['time_zone'] as String? ?? '',
+      workingHours: wh,
+      preferredMeetingTimes:
+          (json['preferred_meeting_times'] as List<dynamic>? ?? [])
+              .map((e) => TimeWindow.fromJson(e as Map<String, dynamic>))
+              .toList(),
+      daysOff: (json['days_off'] as List<dynamic>? ?? []).cast<String>(),
+      preferredBreakDurationMinutes:
+          json['preferred_break_duration_minutes'] as int? ?? 0,
+      workBlockMaxDurationMinutes:
+          json['work_block_max_duration_minutes'] as int? ?? 0,
+      createdAt: json['created_at'] as int? ?? 0,
+      updatedAt: json['updated_at'] as int? ?? 0,
+      darkMode: json['darkMode'] as bool? ?? false,
+    );
+  }
+
+  Map<String, dynamic> toBackendJson() => {
+        'user_id': userId,
+        'time_zone': timeZone,
+        'working_hours':
+            workingHours.map((k, v) => MapEntry(k, v.toJson())),
+        'preferred_meeting_times':
+            preferredMeetingTimes.map((e) => e.toJson()).toList(),
+        'days_off': daysOff,
+        'preferred_break_duration_minutes': preferredBreakDurationMinutes,
+        'work_block_max_duration_minutes': workBlockMaxDurationMinutes,
+      };
+
+  Map<String, dynamic> toJson() => {
+        ...toBackendJson(),
+        'created_at': createdAt,
+        'updated_at': updatedAt,
         'darkMode': darkMode,
       };
 
   UserPreferences copyWith({bool? darkMode}) {
-    return UserPreferences(darkMode: darkMode ?? this.darkMode);
+    return UserPreferences(
+      userId: userId,
+      timeZone: timeZone,
+      workingHours: workingHours,
+      preferredMeetingTimes: preferredMeetingTimes,
+      daysOff: daysOff,
+      preferredBreakDurationMinutes: preferredBreakDurationMinutes,
+      workBlockMaxDurationMinutes: workBlockMaxDurationMinutes,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      darkMode: darkMode ?? this.darkMode,
+    );
   }
 }

--- a/lib/src/services/calendar_service.dart
+++ b/lib/src/services/calendar_service.dart
@@ -2,10 +2,11 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../auth/auth_provider.dart';
 import '../events/calendar_event.dart';
+import '../events/events_response.dart';
 
 const String _apiBaseUrl = 'http://192.168.1.22:8001/Prod';
 //const String _apiBaseUrl = 'https://ww62jfo5jh.execute-api.eu-north-1.amazonaws.com/Prod';
-const String _eventsEndpoint = _apiBaseUrl + '/events';
+String _eventsEndpoint(String userId) => '$_apiBaseUrl/events/$userId/upcoming';
 
 class CalendarServiceError extends Error {
   final String message;
@@ -23,24 +24,28 @@ class CalendarService {
       : _client = client ?? http.Client(),
         _authProvider = authProvider;
 
-  Future<List<CalendarEvent>> fetchEvents() async {
+  Future<EventsResponse> fetchUpcomingEvents({int days = 7, String timezone = 'UTC'}) async {
     final token = _authProvider.backendAccessToken;
-    if (token == null) {
+    final userId = _authProvider.currentUserUuid;
+    if (token == null || userId.isEmpty) {
       throw CalendarServiceError('Not authenticated', statusCode: 401);
     }
+    final uri = Uri.parse(_eventsEndpoint(userId)).replace(queryParameters: {
+      'days': days.toString(),
+      'timezone': timezone,
+    });
     try {
       final response = await _client.get(
-        Uri.parse(_eventsEndpoint),
+        uri,
         headers: {
           'Authorization': 'Bearer $token',
           'Accept': 'application/json'
         },
       );
       if (response.statusCode >= 200 && response.statusCode < 300) {
-        final List<dynamic> data = jsonDecode(response.body) as List<dynamic>;
-        return data
-            .map((e) => CalendarEvent.fromJson(e as Map<String, dynamic>))
-            .toList();
+        final Map<String, dynamic> data =
+            jsonDecode(response.body) as Map<String, dynamic>;
+        return EventsResponse.fromJson(data);
       } else {
         throw CalendarServiceError('Request failed',
             statusCode: response.statusCode);


### PR DESCRIPTION
## Summary
- implement detailed `CalendarEvent` model
- add `EventsResponse` model and update `CalendarService` to call `/events/{user_id}/upcoming`
- adjust `EventProvider` and events view to use new response
- overhaul user preferences model according to backend spec
- update `PreferenceService` to use `/preferences/{user_id}` and send/receive new format
- display more preference information in UI

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*
- `ls test`