### PR TITLE
Load previous chats on login

### DIFF
--- a/lib/src/chat/chat_screen.dart
+++ b/lib/src/chat/chat_screen.dart
@@ -28,6 +28,10 @@ class _ChatScreenState extends State<ChatScreen> {
     super.initState();
     // Initial scroll if there are messages (e.g., welcome message from ChatProvider)
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      final auth = context.read<AuthProvider>();
+      if (auth.currentUserUuid.isNotEmpty) {
+        context.read<ChatProvider>().loadLatestConversation(auth.currentUserUuid);
+      }
       _scrollToBottom(animate: false);
     });
   }


### PR DESCRIPTION
## Summary
- add conversation history models and fetching method in `ChatService`
- support loading latest conversation in `ChatProvider`
- request history during `ChatScreen` initialization

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6839e6472b9c832686131590723eebb8