### PR TITLE
Add language preference option

### DIFF
--- a/lib/src/preferences/parameters_screen.dart
+++ b/lib/src/preferences/parameters_screen.dart
@@ -14,6 +14,13 @@ const List<String> _timeZones = [
   'Asia/Tokyo'
 ];
 
+const Map<String, String> _languages = {
+  'en': 'English',
+  'fr': 'French',
+  'de': 'German',
+  'es': 'Spanish',
+};
+
 class ParametersScreen extends StatefulWidget {
   const ParametersScreen({super.key});
 
@@ -90,7 +97,7 @@ class _ParametersScreenState extends State<ParametersScreen> {
                         );
                       }
                     },
-                  ),
+                    ),
                   if (prefs.inputMode != InputMode.text)
                     ListTile(
                       title: const Text('Voice Button Position'),
@@ -116,6 +123,33 @@ class _ParametersScreenState extends State<ParametersScreen> {
                         }
                       },
                     ),
+                  ListTile(
+                    title: const Text('Language'),
+                    subtitle:
+                        Text(_languages[prefs.language] ?? prefs.language),
+                    trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+                    onTap: () async {
+                      final selected = await showDialog<String>(
+                        context: context,
+                        builder: (context) => SimpleDialog(
+                          title: const Text('Select Language'),
+                          children: _languages.entries
+                              .map(
+                                (e) => SimpleDialogOption(
+                                  onPressed: () => Navigator.pop(context, e.key),
+                                  child: Text(e.value),
+                                ),
+                              )
+                              .toList(),
+                        ),
+                      );
+                      if (selected != null) {
+                        prefsProvider.updatePreferences(
+                          prefs.copyWith(language: selected),
+                        );
+                      }
+                    },
+                  ),
                   ListTile(
                     title: const Text('Time Zone'),
                     subtitle: Text(prefs.timeZone.isEmpty ? 'Select' : prefs.timeZone),

--- a/lib/src/preferences/user_preferences.dart
+++ b/lib/src/preferences/user_preferences.dart
@@ -2,6 +2,8 @@ enum InputMode { text, voice, both }
 
 enum VoiceButtonPosition { left, right }
 
+const List<String> supportedLanguages = ['en', 'fr', 'de', 'es'];
+
 class TimeWindow {
   final String start;
   final String end;
@@ -34,6 +36,7 @@ class UserPreferences {
   final bool darkMode;
   final InputMode inputMode;
   final VoiceButtonPosition voiceButtonPosition;
+  final String language;
 
   UserPreferences({
     required this.userId,
@@ -48,6 +51,7 @@ class UserPreferences {
     this.darkMode = false,
     this.inputMode = InputMode.text,
     this.voiceButtonPosition = VoiceButtonPosition.right,
+    this.language = 'en',
   });
 
   factory UserPreferences.fromJson(Map<String, dynamic> json) {
@@ -81,6 +85,7 @@ class UserPreferences {
       voiceButtonPosition: VoiceButtonPosition.values.firstWhere(
           (e) => e.name == (json['voice_button_position'] as String?),
           orElse: () => VoiceButtonPosition.right),
+      language: json['language'] as String? ?? 'en',
     );
   }
 
@@ -96,6 +101,7 @@ class UserPreferences {
         'work_block_max_duration_minutes': workBlockMaxDurationMinutes,
         'input_mode': inputMode.name,
         'voice_button_position': voiceButtonPosition.name,
+        'language': language,
       };
 
   Map<String, dynamic> toJson() => {
@@ -103,6 +109,7 @@ class UserPreferences {
         'created_at': createdAt,
         'updated_at': updatedAt,
         'darkMode': darkMode,
+        'language': language,
       };
 
   UserPreferences copyWith({
@@ -110,6 +117,7 @@ class UserPreferences {
     String? timeZone,
     InputMode? inputMode,
     VoiceButtonPosition? voiceButtonPosition,
+    String? language,
   }) {
     return UserPreferences(
       userId: userId,
@@ -124,6 +132,7 @@ class UserPreferences {
       darkMode: darkMode ?? this.darkMode,
       inputMode: inputMode ?? this.inputMode,
       voiceButtonPosition: voiceButtonPosition ?? this.voiceButtonPosition,
+      language: language ?? this.language,
     );
   }
 }

--- a/lib/src/services/preference_service.dart
+++ b/lib/src/services/preference_service.dart
@@ -49,6 +49,7 @@ class PreferenceService {
               updatedAt: 0,
               inputMode: InputMode.text,
               voiceButtonPosition: VoiceButtonPosition.right,
+              language: 'en',
             );
     }
 
@@ -78,7 +79,8 @@ class PreferenceService {
               updatedAt: 0,
               darkMode: false,
               inputMode: InputMode.text,
-              voiceButtonPosition: VoiceButtonPosition.right
+              voiceButtonPosition: VoiceButtonPosition.right,
+              language: 'en'
             );
   }
 

--- a/tasks.md
+++ b/tasks.md
@@ -19,4 +19,7 @@ The audio file  identifier in S3 (url or id) must be sent in the body when sendi
    - **Implemented**: token validity is verified on startup via `/auth/me`. Unauthorized responses from the API trigger a logout and redirect to the login screen.
 6) Google custom scheme in google_auth_service.dart should not be hard coded. Move all of them to .env file
 
-7) Add language preferences in the parameters screen
+7) ~~Add language preferences in the parameters screen~~
+   - **Implemented**: users can now choose a preferred UI language from English,
+     French, German or Spanish in the Parameters screen. The chosen code is
+     stored in user preferences.


### PR DESCRIPTION
## Summary
- allow selecting a preferred language in `ParametersScreen`
- store the language code in `UserPreferences`
- persist default language in `PreferenceService`
- mark language preference task as complete

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ea1e14e2483268acfa4ed3f354a9a